### PR TITLE
Use 'dot -Tsvg_inline' to render diagrams

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,6 +7,15 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+
+    services:
+      graphviz:
+        image: ghcr.io/ikalnytskyi/dot:latest
+        options: --name graphviz --interactive
+        credentials:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
     - uses: actions/checkout@v2
 
@@ -17,7 +26,13 @@ jobs:
 
     - name: Set up dependencies
       run: |
-        sudo apt install inkscape graphviz
+        sudo apt install inkscape
+
+        cat << EOF > /usr/local/bin/dot
+        #!/bin/sh
+        exec /usr/bin/docker exec --interactive graphviz /usr/bin/dot \$@
+        EOF
+        chmod +x /usr/local/bin/dot
 
         python -m pip install --upgrade pip
         python -m pip install --requirement requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ on:
 jobs:
   Test:
     runs-on: ubuntu-latest
+
+    services:
+      graphviz:
+        image: ghcr.io/ikalnytskyi/dot:latest
+        options: --name graphviz --interactive
+        credentials:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
     - uses: actions/checkout@v2
 
@@ -19,7 +28,13 @@ jobs:
 
     - name: Set up dependencies
       run: |
-        sudo apt install inkscape graphviz
+        sudo apt install inkscape
+
+        cat << EOF > /usr/local/bin/dot
+        #!/bin/sh
+        exec /usr/bin/docker exec --interactive graphviz /usr/bin/dot \$@
+        EOF
+        chmod +x /usr/local/bin/dot
 
         python -m pip install --upgrade pip
         python -m pip install --requirement requirements.txt

--- a/posts/2023-11-14_on-tmux-osc52-support/index.markdown
+++ b/posts/2023-11-14_on-tmux-osc52-support/index.markdown
@@ -21,7 +21,7 @@ within. Needless to say that a NeoVim instance running inside container has no
 access to the system clipboard[^2], and this is where OSC-52 comes to the
 rescue!
 
-```dot { "exec": ["dot", "-Tsvg"] }
+```dot { "exec": ["dot", "-Tsvg_inline"] }
 digraph G {
     pencolor = "#2E3440"
     style = dashed
@@ -78,7 +78,7 @@ copying: we just send a text we want to copy to all clients and let their
 terminal emulators to set the system clipboard. But what should we do with
 pasting? What attached client should be used as a clipboard source?
 
-```dot { "exec": ["dot", "-Tsvg"] }
+```dot { "exec": ["dot", "-Tsvg_inline"] }
 digraph G {
     pencolor = "#2E3440"
     style = dashed


### PR DESCRIPTION
The `svg_inline` output format has been added to Graphviz 10.0, and
doesn't contain XML headers, making rendered SVGs suitable for embedding
into web pages. This patch brings in a new graphviz version via
container, and sets up `dot` executable that invokes the dot binary
inside container. This works faster than creating a new container every
time we need `dot`.