### PR TITLE
Add Fediverse creator tag to posts

### DIFF
--- a/.holocron.yml
+++ b/.holocron.yml
@@ -114,8 +114,8 @@ pipes:
               - Talks: /talks/
               - Feed: /feed.xml
 
-            twitter_cards:
-              username: ikalnytskyi
+            fediverse:
+              creator: "@ihor@fosstodon.org"
       when:
         - |
           "template" in item or (

--- a/_theme/templates/item.j2
+++ b/_theme/templates/item.j2
@@ -16,11 +16,13 @@
     <meta name="description" content="{{ summary }}" />
   {% endif %}
 
-  {% if theme.twitter_cards.username and item.summary %}
+  {% if item.summary %}
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@{{ theme.twitter_cards.username }}" />
-    <meta name="twitter:title" content="{{ item.title }}" />
     <meta name="twitter:description" content="{{ summary }}" />
+    <meta name="twitter:title" content="{{ item.title }}" />
+  {% if theme.twitter_cards and theme.twitter_cards.username %}
+    <meta name="twitter:site" content="@{{ theme.twitter_cards.username }}" />
+  {% endif %}
   {% endif %}
 
     <meta property="og:title" content="{{ item.title }}" />
@@ -36,6 +38,10 @@
     <meta property="article:author" content="{{ author }}" />
   {% else %}
     <meta property="og:type" content="website" />
+  {% endif %}
+
+  {% if theme.fediverse and theme.fediverse.creator %}
+    <meta name="fediverse:creator" content="{{ theme.fediverse.creator }}" />
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
To reinforce and encourage Mastodon as the go-to place for journalism, they have launced a new feature [1] where underneath some links shared on Mastodon, the author byline can be clicked to open the author’s associated fediverse account, right in the app.

Even though I'm neither popular blogger nor journalist, it does seem right to promote my fediverse account there.

[1] htotps://blog.joinmastodn.org/2024/07/highlighting-journalism-on-mastodon/