### PR TITLE
Heavy CD refactoring

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,16 +5,8 @@ on:
     branches: [master]
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-
-    services:
-      graphviz:
-        image: ghcr.io/ikalnytskyi/dot:latest
-        options: --name graphviz --interactive
-        credentials:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -22,26 +14,47 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.13"
 
-    - name: Set up dependencies
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Set up Inkscape
+      run: sudo apt install inkscape
+
+    - name: Set up Graphviz
       run: |
-        sudo apt install inkscape
+        curl -L -o "${{ runner.temp }}/graphviz.deb" "$GRAPHVIZ_DEB_URL"
+        sudo apt install "${{ runner.temp }}/graphviz.deb"
+      env:
+        GRAPHVIZ_DEB_URL: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/ubuntu_24.04_graphviz-12.2.1-cmake.deb
 
-        cat << EOF > /usr/local/bin/dot
-        #!/bin/sh
-        exec /usr/bin/docker exec --interactive graphviz /usr/bin/dot \$@
-        EOF
-        chmod +x /usr/local/bin/dot
-
-        python -m pip install --upgrade pip
-        python -m pip install --requirement requirements.txt
+    - name: Set up Holocron
+      run: uv tool install "$HOLOCRON_PYTHON_PACKAGE"
+      env:
+        HOLOCRON_PYTHON_PACKAGE: git+https://github.com/ikalnytskyi/holocron.git@284d21c96a6b9fda689c7f3828d9d531c0865a9b
 
     - name: Run Holocron
       run: holocron run compile
 
-    - name: Publish kalnytskyi.com
-      uses: peaceiris/actions-gh-pages@v4
+    - name: Upload GitHub Pages archive
+      uses: actions/upload-pages-artifact@v3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./_site
+        path: _site/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-24.04
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: kalnytskyi.com
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Publish to GitHub Pages
+        uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
There are a bunch of significant changes in continues delivery workflow
in this patch:

* Switching from third-party to official github actions to publish my
  site to github pages.

* Using environments and branch protection to selectively support only
  certain branches for deployment.

* Using pre-compiled Graphviz binaries instead of a hack with background
  Docker service.

* Using uv to install the holocron package.