### PR TITLE
Fix CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,15 +17,15 @@ jobs:
         python-version: "3.13"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v6
 
     - name: Set up Inkscape
-      run: sudo apt install inkscape
+      run: sudo apt-get update && sudo apt-get install inkscape
 
     - name: Set up Graphviz
       run: |
         curl -L -o "${{ runner.temp }}/graphviz.deb" "$GRAPHVIZ_DEB_URL"
-        sudo apt install "${{ runner.temp }}/graphviz.deb"
+        sudo apt-get install "${{ runner.temp }}/graphviz.deb"
       env:
         GRAPHVIZ_DEB_URL: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/ubuntu_24.04_graphviz-12.2.1-cmake.deb
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -19,15 +19,15 @@ jobs:
         python-version: "3.13"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v6
 
     - name: Set up Inkscape
-      run: sudo apt install inkscape
+      run: sudo apt-get update && sudo apt-get install inkscape
 
     - name: Set up Graphviz
       run: |
         curl -L -o "${{ runner.temp }}/graphviz.deb" "$GRAPHVIZ_DEB_URL"
-        sudo apt install "${{ runner.temp }}/graphviz.deb"
+        sudo apt-get install "${{ runner.temp }}/graphviz.deb"
       env:
         GRAPHVIZ_DEB_URL: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/ubuntu_24.04_graphviz-12.2.1-cmake.deb
 


### PR DESCRIPTION
It seems the CI/CD pipelines are broken now. Most notably because Inkscape version being cached in apt cache doesn't match the version served by the repository. There was a mistake that pipelines didn't refresh the cache first.